### PR TITLE
Set dependencies properly for xbps-create

### DIFF
--- a/iglupkg.sh
+++ b/iglupkg.sh
@@ -204,7 +204,7 @@ _x() {
 	t_deps=$(printf '%s\n' $@ | grep -v '>=')
 	if [ ! -z "$t_deps" ]
 	then
-		n_deps=$(printf '%s\n' $@ | grep -v '>=' | awk '{printf $0">=0"}')
+		n_deps=$(printf '%s\n' $@ | grep -v '>=' | awk '{printf $0">=0 "}')
 	fi
 	y_deps=$(printf '%s\n' $@ | grep '>=' || : )
 	cd "$outdir"


### PR DESCRIPTION
xbps-create expects dependencies to be separated by an whitespace.. currently dependencies are given to xbps-create without whitespace, resulting in packages with broken deps.

This PR fixes this issue.